### PR TITLE
数学系ページのUI改善 (Collatz計算ボタン追加など)

### DIFF
--- a/components/math/Collatz.tsx
+++ b/components/math/Collatz.tsx
@@ -1,7 +1,7 @@
-
 import { useState } from "react";
 import { Input } from "@nextui-org/input";
 import { Table, TableBody, TableCell, TableHeader, TableColumn, TableRow } from "@nextui-org/react";
+import { Button } from "@nextui-org/button";
 import { collatz, CollatzStep } from "../../utils/math";
 
 const columns = [
@@ -20,14 +20,15 @@ const columns = [
 ];
 
 export function Collatz() {
-    const [value, setValue] = useState<string>("1");
+    const [inputValue, setInputValue] = useState<string>("");
+    const [targetValue, setTargetValue] = useState<string>("1");
 
     // Parse input, defaulting to 1 if invalid
     let n: bigint = 1n;
     let isValid = false;
     try {
-        if (value.trim() !== "") {
-            n = BigInt(value);
+        if (targetValue.trim() !== "") {
+            n = BigInt(targetValue);
             isValid = n >= 1n;
         }
     } catch {
@@ -38,21 +39,31 @@ export function Collatz() {
     const steps: CollatzStep[] = isValid ? collatz(n) : [];
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setValue(e.target.value)
+        setInputValue(e.target.value)
+    }
+
+    const handleCalculate = () => {
+        setTargetValue(inputValue);
     }
 
     return (
         <div className="flex flex-col gap-4">
-            <Input
-                id="value"
-                type="number"
-                label="数値"
-                placeholder="正の整数"
-                value={value}
-                min={1}
-                onChange={handleChange}
-                size="lg"
-            />
+            <div className="flex gap-2 items-end">
+                <Input
+                    id="value"
+                    type="number"
+                    label="数値"
+                    placeholder="正の整数"
+                    value={inputValue}
+                    min={1}
+                    onChange={handleChange}
+                    size="lg"
+                    className="flex-grow"
+                />
+                <Button color="primary" onClick={handleCalculate} size="lg">
+                    計算
+                </Button>
+            </div>
             {isValid && (
                 <Table aria-label="Collatz operation table">
                     <TableHeader columns={columns}>
@@ -61,9 +72,15 @@ export function Collatz() {
                     <TableBody items={steps}>
                         {(item) => (
                             <TableRow key={item.step}>
-                                <TableCell>{item.step}</TableCell>
-                                <TableCell>{item.value.toString()}</TableCell>
-                                <TableCell>{item.operation}</TableCell>
+                                <TableCell>
+                                    <span className="font-mono">{item.step}</span>
+                                </TableCell>
+                                <TableCell>
+                                    <span className="break-all font-mono">{item.value.toString()}</span>
+                                </TableCell>
+                                <TableCell>
+                                    <span className="break-all font-mono">{item.operation}</span>
+                                </TableCell>
                             </TableRow>
                         )}
                     </TableBody>

--- a/components/math/PrimeFactorization.tsx
+++ b/components/math/PrimeFactorization.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from "react";
 import { Input } from "@nextui-org/input";
 import { Button } from "@nextui-org/button"; // Import Button
@@ -65,7 +64,7 @@ export function PrimeFactorization() {
             {isValid && n !== null && (
                 <Card>
                     <CardBody>
-                        <div className="text-2xl font-mono text-center break-all">
+                        <div className="text-xl md:text-2xl font-mono text-center break-all">
                             {n.toString()} = {formatFactors(factors)}
                         </div>
                     </CardBody>


### PR DESCRIPTION
## 概要
Collatzページと素因数分解ページのUI/UXを改善しました。

## 変更点
- **Collatzページ**:
  - パフォーマンス改善とUX統一のため、「計算」ボタンを追加しました。
  - 長い数字がテーブルからはみ出ないように  を適用しました。
  - 数字に等幅フォントを適用しました。
- **素因数分解ページ**:
  - モバイル環境での表示崩れを防ぐため、結果表示のフォントサイズをレスポンシブ () に変更しました。

## 確認方法
- `/ja/math/collatz` にアクセスし、数字を入力して「計算」ボタンで結果が表示されることを確認してください。
- 非常に大きな数字を入力してもテーブルが崩れないことを確認してください。
- `/ja/math/prime-factorization` でレスポンシブ挙動を確認してください。

## 備考
- ビルド時にTypeScriptバージョンの不整合によるエラーが出ますが、既存環境に起因するものであり、本PRの変更とは無関係です。