### PR TITLE
chore: octocovでカバレッジ差分レポートを設定

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      actions: read
 
     steps:
     - uses: actions/checkout@v4

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,15 @@
 coverage:
   paths:
     - coverage/lcov.info
+
 comment:
   if: is_pull_request
+
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
## 概要
Octocovを設定し、Pull Request上でメインブランチとのカバレッジ差分をレポートするようにしました。

## 変更点
- **.octocov.yml**: `report`と`diff`セクションを追加し、GitHub Artifactsを使用してカバレッジデータを保存・参照するように設定しました。
- **.github/workflows/test.yml**: octocovがアーティファクトにアクセスできるように`actions: read`権限を追加しました。

## 検証
このPRがマージされた後、`main`ブランチでカバレッジデータが保存されます。
その後のPRから、カバレッジ差分が表示されるようになります。
