### PR TITLE
fix: improve mobile UI and responsive layout

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,6 +1,6 @@
 export default function DocsPage() {
     return (
-        <div className="container mx-auto py-10">
+        <div className="container mx-auto py-10 px-6 md:px-8">
             <div className="mx-auto max-w-3xl space-y-8">
                 <h1 className="text-4xl font-bold tracking-tight">Introduction</h1>
                 <div className="space-y-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
               This project is an experiment to see how we can build a modern toolkit app with Next.js 15 and shadcn/ui.
             </p>
           </div>
-          <div className="mx-auto grid justify-center gap-4 sm:grid-cols-2 md:max-w-[64rem] md:grid-cols-3">
+          <div className="mx-auto grid gap-4 grid-cols-2 md:max-w-[64rem] md:grid-cols-3">
             <Link href="/tools/json-formatter">
               <Card className="h-full hover:bg-muted/50 transition-colors">
                 <CardHeader>

--- a/src/app/tools/layout.tsx
+++ b/src/app/tools/layout.tsx
@@ -1,9 +1,16 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import {
     ArrowLeft,
@@ -54,9 +61,10 @@ const sidebarItems = [
 
 export default function ToolsLayout({ children }: ToolsLayoutProps) {
     const pathname = usePathname()
+    const router = useRouter()
 
     return (
-        <div className="container mx-auto flex flex-col gap-6 py-8 md:py-10">
+        <div className="container mx-auto flex flex-col gap-6 py-8 md:py-10 px-6 md:px-8">
             <div className="flex w-full flex-col items-start gap-4">
                 {/* Back to Home button removed as it is redundant with global header */}
                 <div className="grid w-full gap-2">
@@ -72,7 +80,30 @@ export default function ToolsLayout({ children }: ToolsLayoutProps) {
 
             <div className="flex flex-col space-y-8 lg:flex-row lg:space-x-12 lg:space-y-0">
                 <aside className="-mx-4 lg:mx-0 lg:w-1/5 lg:pr-8">
-                    <nav className="flex space-x-2 lg:flex-col lg:space-x-0 lg:space-y-1 overflow-x-auto pb-4 lg:pb-0 px-4 lg:px-0">
+                    {/* Mobile Navigation (Select) */}
+                    <div className="px-4 lg:hidden">
+                        <Select
+                            value={pathname}
+                            onValueChange={(value) => router.push(value)}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Select a tool" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {sidebarItems.map((item) => (
+                                    <SelectItem key={item.href} value={item.href}>
+                                        <div className="flex items-center">
+                                            <item.icon className="mr-2 h-4 w-4" />
+                                            {item.title}
+                                        </div>
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Desktop Navigation (Sidebar) */}
+                    <nav className="hidden lg:flex lg:flex-col lg:space-y-1">
                         {sidebarItems.map((item) => (
                             <Button
                                 key={item.href}

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import Link, { LinkProps } from "next/link"
+import { useRouter } from "next/navigation"
+import { Monitor, FileText, Menu, Settings } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger, SheetTitle, SheetDescription } from "@/components/ui/sheet"
+
+export function MobileNav() {
+    const [open, setOpen] = React.useState(false)
+
+    return (
+        <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+                <Button variant="ghost" className="mr-2 px-0 text-base hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 md:hidden">
+                    <Menu className="h-5 w-5" />
+                    <span className="sr-only">Toggle Menu</span>
+                </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="pl-6 pr-6 pt-10">
+                <SheetTitle className="sr-only">Mobile Navigation</SheetTitle>
+                <SheetDescription className="sr-only">Main navigation menu</SheetDescription>
+
+                <div className="px-2 mb-8">
+                    <MobileLink
+                        href="/"
+                        className="flex items-center"
+                        onOpenChange={setOpen}
+                    >
+                        <span className="font-bold text-lg tracking-tight">Toolkit</span>
+                    </MobileLink>
+                </div>
+
+                <div className="flex flex-col space-y-4 px-2">
+                    <MobileLink href="/docs" onOpenChange={setOpen} className="text-muted-foreground hover:text-foreground transition-colors">
+                        <div className="flex items-center gap-4 py-2">
+                            <FileText className="h-5 w-5" />
+                            <span className="text-base font-medium">Docs</span>
+                        </div>
+                    </MobileLink>
+                    <MobileLink href="/tools" onOpenChange={setOpen} className="text-muted-foreground hover:text-foreground transition-colors">
+                        <div className="flex items-center gap-4 py-2">
+                            <Monitor className="h-5 w-5" />
+                            <span className="text-base font-medium">Tools</span>
+                        </div>
+                    </MobileLink>
+                </div>
+            </SheetContent>
+        </Sheet>
+    )
+}
+
+interface MobileLinkProps extends LinkProps {
+    onOpenChange?: (open: boolean) => void
+    children: React.ReactNode
+    className?: string
+}
+
+function MobileLink({
+    href,
+    onOpenChange,
+    className,
+    children,
+    ...props
+}: MobileLinkProps) {
+    const router = useRouter()
+    return (
+        <Link
+            href={href}
+            onClick={() => {
+                router.push(href.toString())
+                onOpenChange?.(false)
+            }}
+            className={cn(className)}
+            {...props}
+        >
+            {children}
+        </Link>
+    )
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link"
 import { Github } from "lucide-react"
 
+import { MobileNav } from "@/components/mobile-nav"
 
 export function SiteHeader() {
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container mx-auto flex h-14 items-center">
+                <MobileNav />
+                <div className="md:hidden absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
+                    <Link href="/" className="font-bold pointer-events-auto">Toolkit</Link>
+                </div>
                 <div className="mr-4 hidden md:flex">
                     <Link className="mr-6 flex items-center space-x-2" href="/">
                         <span className="hidden font-bold sm:inline-block">Toolkit</span>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-tight font-semibold", className)}
       {...props}
     />
   )

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
## 概要
スマートフォンでの表示崩れやUIの問題を修正し、モバイル体験を向上させました。

## 変更点
- **モバイルナビゲーション**: `Sheet` コンポーネントを使用したハンバーガーメニューを実装し、モバイルでもメニューにアクセスできるようにしました。
- **ホーム画面**: カードのレイアウトをモバイルで2列に変更し、タイトルのテキスト折り返しを修正して読みやすくしました。
- **ヘッダー**: モバイル表示時にヘッダー中央に「Toolkit」ロゴを追加し、スカスカな印象を解消しました。
- **Docs/Toolsページ**: コンテナにパディングを追加し、コンテンツが画面端に張り付かないように修正しました。
- **Tools選択**: モバイルでのツール選択を横スクロールリストから `Select` ドロップダウンに変更し、操作性を改善しました。

## 検証
- ローカル環境 (iPhone 375x812 相当) でブラウザ検証を実施。
- 各ページのレイアウト崩れがないこと、ナビゲーションが正常に動作することを確認しました。