### PR TITLE
fix: correct Vercel status check command in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,7 +24,7 @@ jobs:
           echo "Waiting for Vercel Checks..."
           # Poll for up to 10 minutes (60 * 10s)
           for i in {1..60}; do
-             VERCEL_STATUS=$(gh pr checks "$PR_URL" --json name,status,conclusion --jq '.[] | select(.name | test("Vercel"; "i"))')
+             VERCEL_STATUS=$(gh pr view "$PR_URL" --json statusCheckRollup --jq '.statusCheckRollup[] | select((.name // .context) | test("Vercel"; "i")) | { name: (.name // .context), status: (.status // (if .state == "PENDING" then "in_progress" else "completed" end)) | ascii_downcase, conclusion: (.conclusion // (if .state == "SUCCESS" then "success" elif .state == "FAILURE" then "failure" else "neutral" end)) | ascii_downcase }')
              
              if [ -z "$VERCEL_STATUS" ]; then
                 echo "No Vercel check found yet. Waiting..."


### PR DESCRIPTION
## 概要
DependabotのPRで自動マージを行うワークフローにおいて、`gh pr checks` コマンドがエラー（`Unknown JSON field`）で落ちていた問題を修正しました。

## 原因
`gh pr checks` コマンドで `--json` フラグを使用して `status` フィールドを取得しようとしていましたが、このコマンドまたは指定したフィールドが正しくサポートされていなかったためエラーが発生していました。

## 変更内容
`gh pr checks` の代わりに `gh pr view ... --json statusCheckRollup` を使用するように変更しました。
`jq` クエリを使用して、Vercelのステータス（`CheckRun` または `StatusContext`）を適切に抽出し、期待されるフォーマット（`name`, `status`, `conclusion`）に変換するようにしました。

## 検証
ローカル環境にて `gh pr view 188 ...` コマンドを実行し、正しいJSONが出力されることを確認しました。