### PR TITLE
chore: enforce reply to review comments in workflow

### DIFF
--- a/.agent/workflows/handle-review.md
+++ b/.agent/workflows/handle-review.md
@@ -56,4 +56,6 @@ description: Check for PR on current branch and address review comments.
    - **Reply to Review Comments**:
      - You MUST reply to each review comment (using `gh pr comment` or via suggested_responses).
      - **If addressed**: Reply with "Fixed in [commit-hash]. [Brief description of fix]."
+       - Example: "Fixed in 8e2a1b9. Removed the unused variable."
      - **If NOT addressed**: Reply with "Not addressed because [Reason]."
+       - Example: "Not addressed because this will be handled in a separate PR."


### PR DESCRIPTION
## Overview
 ワークフローを更新し、レビューコメントへの返信を義務付けました。

## Changes
- : レビューコメントへの返信ルール（対応内容とコミットハッシュ、または未対応の理由）を明記しました。

## Reason
レビュープロセスにおいて、どのコメントがどのように処理されたかを追跡可能にするため。