### PR TITLE
chore: Enforce 1:1 reply ratio in handle-review workflow

### DIFF
--- a/.agent/workflows/handle-review.md
+++ b/.agent/workflows/handle-review.md
@@ -55,7 +55,7 @@ description: Check for PR on current branch and address review comments.
    ```
    - **Reply to Review Comments**:
      - You MUST reply to **EACH** review comment individually.
-     - **Requirement**: A 1:1 reply ratio is mandatory. If there are 3 review comments, you must post 3 separate replies. Do not group them.
+     - Example: If there are 3 review comments, you must post 3 separate replies. Do not group them.
      - **If addressed**: Reply with "Fixed in [commit-hash]. [Brief description of fix]."
        - Example: "Fixed in 8e2a1b9. Removed the unused variable."
      - **If NOT addressed**: Reply with "Not addressed because [Reason]."


### PR DESCRIPTION
## 概要
レビュー対応ワークフロー (`.agent/workflows/handle-review.md`) を更新し、レビューコメントへの返信に関するルールを厳格化しました。

## 変更点
- レビューコメント1つにつき、必ず個別に返信することを明記しました。
- 複数のコメントに対してまとめて返信することを禁止し、1対1の対応を求める具体例を追加しました。