### PR TITLE
fix: enforce CI coverage threshold for PR diff

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -11,5 +11,6 @@ report:
     - artifact://${GITHUB_REPOSITORY}
 
 diff:
+  target: 80%
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
## Overview
Enforce CI coverage threshold of 80% for PR diff using octocov configuration.
close #211