### PR TITLE
chore: setup devcontainer and update node version to 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-    "name": "Node.js 24 & TypeScript",
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-24-bookworm",
+    "name": "Node.js 22 & TypeScript",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {}
     },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '24'
+        node-version: '22'
         cache: 'pnpm'
 
     - name: Install dependencies


### PR DESCRIPTION
## 概要
開発環境 (.devcontainer) をセットアップし、Node.js のバージョンを 24 から 22 に更新しました。

## 変更点
- `.devcontainer/devcontainer.json` を追加 (Node.js 22 & TypeScript)
- `.github/workflows/test.yml` の Node.js バージョンを 22 に更新