### PR TITLE
fix(ci): setup git config and fetch-depth for octocov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Install pnpm
       uses: pnpm/action-setup@v3
@@ -34,6 +36,11 @@ jobs:
 
     - name: Run tests
       run: pnpm vitest run --coverage --reporter=verbose
+
+    - name: Setup git
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
     - name: Run octocov
       uses: k1LoW/octocov-action@v1


### PR DESCRIPTION
CIエラー修正。
- `actions/checkout`: `fetch-depth: 0` を設定 (Squash merge対策)
- `git config`: `github-actions[bot]` を設定 (バッジコミット用)